### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,19 +8,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           tags: worker-operator:latest
           push: false
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           file: test.Dockerfile
           tags: test-image:latest
           push: false
-      - uses: addnab/docker-run-action@v3
+      - uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:
           image: test-image:latest
           run: make test

--- a/.github/workflows/delete-old-workflow-manual.yaml
+++ b/.github/workflows/delete-old-workflow-manual.yaml
@@ -47,7 +47,7 @@ jobs:
       actions: write
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@v2
+        uses: Mattraks/delete-workflow-runs@b3018382ca039b53d238908238bd35d1fb14f8ee # v2
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}

--- a/.github/workflows/end-to-end-test.yaml
+++ b/.github/workflows/end-to-end-test.yaml
@@ -29,7 +29,7 @@ jobs:
         df . -h
           
     - name: checkout the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -42,10 +42,10 @@ jobs:
      
     - name: Get branch name
       id: branch-name
-      uses: tj-actions/branch-names@v7.0.7
+      uses: tj-actions/branch-names@6c999acf206f5561e19f46301bb310e9e70d8815 # v7.0.7
       
     - name: build the worker operator
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
       with:
         tags: worker-operator:${{ steps.vars.outputs.sha_commit }}
         build-args: |
@@ -53,7 +53,7 @@ jobs:
         push: false
         
     - name: Scanning image for vulnerablilities
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@314ff8b43182423b84c50b1670b0e10f858f2d98 # master
       with:
           image-ref: worker-operator:${{ steps.vars.outputs.sha_commit }}
           format: 'table'
@@ -87,7 +87,7 @@ jobs:
         bash .github/workflows/scripts/binary-image-critical.sh
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
           name: trivy-scan
           path: scan.txt
@@ -121,7 +121,7 @@ jobs:
         df . -h
 
     - name: Docker Run Action
-      uses: addnab/docker-run-action@v3
+      uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
       with:
         username: ${{ env.dockeruser }}
         password: ${{ env.dockerpassword }}
@@ -167,7 +167,7 @@ jobs:
         sudo du /usr/ -hx -d 4 --threshold=1G | sort -hr | head
 
     - name: Checkout gh-pages repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       with:
         repository: kubeslice/e2e-allure-reports
         path: gh-pages
@@ -178,7 +178,7 @@ jobs:
       run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H:%M:%S')"
 
     - name: Allure Report with history
-      uses: PavanMudigonda/allure-html-reporter-github-pages@v1.0
+      uses: PavanMudigonda/allure-html-reporter-github-pages@28bf0da431bc998e9abff4dc70dfc282791cfab8 # v1.0
       id: Allure_report_with_history
       with:
         allure_results: reports
@@ -192,7 +192,7 @@ jobs:
         test_env: Kind
           
     - name: Deploy report to Github Pages
-      uses: peaceiris/actions-gh-pages@v2
+      uses: peaceiris/actions-gh-pages@45b43ab25725682861f953edbb911fe7f402a5b6 # v2
       env:
         PUBLISH_BRANCH: gh-pages
         PERSONAL_TOKEN: ${{ secrets.TOKEN }}
@@ -207,7 +207,7 @@ jobs:
       
     - name: Report link on Pull Request comment
       if: ${{ github.event_name == 'pull_request_target' }}
-      uses: thollander/actions-comment-pull-request@v1
+      uses: thollander/actions-comment-pull-request@8a3fad13c20088e9eb0805666b9fe49509d2fec8 # v1
       with:
         message: |
                  report link  'https://kubeslice.github.io/e2e-allure-reports/Kind-${{ github.event.repository.name }}-${{ steps.date.outputs.date }}-${{ github.base_ref }}-${{ github.run_number }}/index.html'
@@ -224,7 +224,7 @@ jobs:
     
     - name: Send mail
       if: always()
-      uses: dawidd6/action-send-mail@v3
+      uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7 # v3
       with:
        server_address: smtp.gmail.com
        server_port: 465

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout the repo
-        uses: actions/checkout@v2
-      - uses: Jerome1337/gofmt-action@v1.0.4
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: Jerome1337/gofmt-action@4899d680cd7d4a959becfe74f97170c5847f859c # v1.0.4
         name: check go fmt
         with:
           gofmt-path: './'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,16 +26,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -58,7 +58,7 @@ jobs:
             description=Manages the lifecycle of KubeSlice worker cluster-related crds
 
       - name: "Build and push"
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           file: Dockerfile
           context: .
@@ -69,7 +69,7 @@ jobs:
 
       - name: Extract Docker metadata for UBI image
         id: ubi
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -86,7 +86,7 @@ jobs:
             description=Manages the lifecycle of KubeSlice worker cluster-related crds
 
       - name: "Build and push UBI image"
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           file: Dockerfile.ubi
           context: .

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@314ff8b43182423b84c50b1670b0e10f858f2d98 # master
         with:
           scan-type: 'repo'
           ignore-unfixed: true
@@ -34,6 +34,6 @@ jobs:
           TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db"
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- Pin all action and reusable workflow references in `.github/workflows/` to full-length commit SHAs
- Preserves the original version reference as a trailing comment (e.g. `@<sha> # v4`)

Improves supply-chain security per OpenSSF Scorecard / StepSecurity guidance.

## Test plan
- [ ] CI passes on this branch (workflows still resolve)